### PR TITLE
using version "1.0.1-TENANT" of "com.microfocus.adm.performancecenter…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
         <dependency>
             <groupId>com.microfocus.adm.performancecenter</groupId>
             <artifactId>plugins-common</artifactId>
-            <version>1.1.8</version>
+            <version>1.0.1-TENANT</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
…" dependency (similar in all with version 1.0.1 that was used before and did not cause conflicts).