### PR TITLE
fixing log4j dependency to avoid warnings regarding CVE-2021-44228, CVE-2021-45105, CVE-2021-44832

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.16.0</version>
+            <version>2.17.0</version>
         </dependency>
         
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,12 @@
             <version>${plugin.testrunner.version}</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.16.0</version>
+        </dependency>
+        
         <dependency>
             <groupId>com.microfocus.sv</groupId>
             <artifactId>SVConfigurator</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.17.0</version>
+            <version>2.17.1</version>
         </dependency>
         
         <dependency>


### PR DESCRIPTION
Due to CVE-2021-44228 we need to avoid any vulnerable log4j-core in the final jars, which are currently in the addon's jar. The log4j found is 2.6.2. 
This PR is a bit a shot in the dark, but for us at least the warnings went away and the app still seems to work fine. The dependency seems to come from `com.hpe.adm.octane.ciplugins:integrations-sdk`, which maybe need a separate update and would make this PS obsolete. 