### PR TITLE
Rebranding from Microfocus to OpenText 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <dependency>
             <groupId>com.microfocus.adm.performancecenter</groupId>
             <artifactId>plugins-common</artifactId>
-            <version>1.0.2-TENANT</version>
+            <version>1.1.11</version>
         </dependency>
 
         <!-- !!!!! VERY IMPORTANT NOTE: jakarta.xml.bind-api 3.0.0-RC1 is required to get rid of JAXB runtime errors, even if it is not used in code, so please do not remove it, unless your are sure the JAXB objects are working with remote agents using either JDK1.8 or JDK11 -->

--- a/src/main/java/com/adm/bamboo/plugin/performancecenter/TaskConfigurator.java
+++ b/src/main/java/com/adm/bamboo/plugin/performancecenter/TaskConfigurator.java
@@ -1,22 +1,22 @@
 /*
- * Certain versions of software and/or documents ("Material") accessible here may contain branding from
- * Hewlett-Packard Company (now HP Inc.) and Hewlett Packard Enterprise Company.  As of September 1, 2017,
- * the Material is now offered by Open Text Corporation, a separately owned and operated company.  Any reference to the HP
- * and Hewlett Packard Enterprise/HPE marks is historical in nature, and the HP and Hewlett Packard Enterprise/HPE
- * marks are the property of their respective owners.
- * __________________________________________________________________
- * MIT License
- *
- * Copyright © 2023 Open Text Corporation
- *
- * The only warranties for products and services of Open Text Corporation
- * are set forth in the express warranty statements
- * accompanying such products and services. Nothing herein should be construed as
- * constituting an additional warranty. Open Text shall not be liable for technical
- * or editorial errors or omissions contained herein.
- * The information contained herein is subject to change without notice.
- * ___________________________________________________________________
- */
+* Certain versions of software and/or documents ("Material") accessible here may contain branding from
+* Hewlett-Packard Company (now HP Inc.) and Hewlett Packard Enterprise Company.
+* The Material is now offered by Open Text Corporation, a separately owned and operated company.  Any reference to the HP
+* and Hewlett Packard Enterprise/HPE marks is historical in nature, and the HP and Hewlett Packard Enterprise/HPE
+* marks are the property of their respective owners.
+* __________________________________________________________________
+* MIT License
+*
+* Copyright © 2023 Open Text Corporation
+*
+* The only warranties for products and services of Open Text Corporation
+* are set forth in the express warranty statements
+* accompanying such products and services. Nothing herein should be construed as
+* constituting an additional warranty. Open Text shall not be liable for technical
+* or editorial errors or omissions contained herein.
+* The information contained herein is subject to change without notice.
+* ___________________________________________________________________
+*/
 
 package com.adm.bamboo.plugin.performancecenter;
 

--- a/src/main/java/com/adm/bamboo/plugin/performancecenter/TaskConfigurator.java
+++ b/src/main/java/com/adm/bamboo/plugin/performancecenter/TaskConfigurator.java
@@ -1,18 +1,18 @@
 /*
  * Certain versions of software and/or documents ("Material") accessible here may contain branding from
  * Hewlett-Packard Company (now HP Inc.) and Hewlett Packard Enterprise Company.  As of September 1, 2017,
- * the Material is now offered by Micro Focus, a separately owned and operated company.  Any reference to the HP
+ * the Material is now offered by Open Text Corporation, a separately owned and operated company.  Any reference to the HP
  * and Hewlett Packard Enterprise/HPE marks is historical in nature, and the HP and Hewlett Packard Enterprise/HPE
  * marks are the property of their respective owners.
  * __________________________________________________________________
  * MIT License
  *
- * (c) Copyright 2012-2019 Micro Focus or one of its affiliates.
+ * Copyright © 2023 Open Text Corporation
  *
- * The only warranties for products and services of Micro Focus and its affiliates
- * and licensors ("Micro Focus") are set forth in the express warranty statements
+ * The only warranties for products and services of Open Text Corporation
+ * are set forth in the express warranty statements
  * accompanying such products and services. Nothing herein should be construed as
- * constituting an additional warranty. Micro Focus shall not be liable for technical
+ * constituting an additional warranty. Open Text shall not be liable for technical
  * or editorial errors or omissions contained herein.
  * The information contained herein is subject to change without notice.
  * ___________________________________________________________________
@@ -20,11 +20,11 @@
 
 package com.adm.bamboo.plugin.performancecenter;
 
-import com.microfocus.adm.performancecenter.plugins.common.pcentities.*;
 import com.atlassian.bamboo.collections.ActionParametersMap;
 import com.atlassian.bamboo.task.AbstractTaskConfigurator;
 import com.atlassian.bamboo.task.TaskDefinition;
 import com.atlassian.bamboo.utils.error.ErrorCollection;
+import com.microfocus.adm.performancecenter.plugins.common.pcentities.PostRunAction;
 import org.apache.commons.lang.StringUtils;
 
 import java.util.ArrayList;
@@ -36,42 +36,37 @@ import java.util.Map;
  */
 public class TaskConfigurator extends AbstractTaskConfigurator {
 
-    public static final String PC_SERVER ="LRE Server";
-    public static final String USER ="User name";
-    public static final String HTTPS ="https";
-    public static final String PASSWORD ="Password";
-    public static final String DOMAIN ="Domain";
-    public static final String PROJECT ="PC Project";
-    public static final String TEST_ID ="Test ID";
-    public static final String TEST_INSTANCE_ID ="Test Instance ID";
-    public static final String TEST_INSTANCE_ID_RADIO ="TestInstanceIDRadio";
-    public static final String LOCAL_PROXY ="Local Proxy";
-    public static final String PROXY_USER ="ProxyUser";
-    public static final String PROXY_PASSWORD ="ProxyPassword";
+    public static final String PC_SERVER = "LRE Server";
+    public static final String USER = "User name";
+    public static final String HTTPS = "https";
+    public static final String PASSWORD = "Password";
+    public static final String DOMAIN = "Domain";
+    public static final String PROJECT = "PC Project";
+    public static final String TEST_ID = "Test ID";
+    public static final String TEST_INSTANCE_ID = "Test Instance ID";
+    public static final String TEST_INSTANCE_ID_RADIO = "TestInstanceIDRadio";
+    public static final String LOCAL_PROXY = "Local Proxy";
+    public static final String PROXY_USER = "ProxyUser";
+    public static final String PROXY_PASSWORD = "ProxyPassword";
     public static final String POST_RUN_ACTION = "postRunAction";
-    public static final String TRENDING_RADIO ="trendingRadio";
-    public static final String TREND_REPORT_ID ="Trend Report ID";
-    public static final String TIMESLOT_HOURS ="Hours";
-    public static final String TIMESLOT_MINUTES ="Minutes";
-    public static final String VUDS ="vuds";
-    public static final String SLA ="sla";
+    public static final String TRENDING_RADIO = "trendingRadio";
+    public static final String TREND_REPORT_ID = "Trend Report ID";
+    public static final String TIMESLOT_HOURS = "Hours";
+    public static final String TIMESLOT_MINUTES = "Minutes";
+    public static final String VUDS = "vuds";
+    public static final String SLA = "sla";
     public static final String AUTHENTICATE_WITH_TOKEN = "authenticateWithToken";
-
-    public Map<String,String> postRunActionMap = new LinkedHashMap<String, String>();
-    public Map<String,String> testInstanceMap = new LinkedHashMap<String, String>();
-    public Map<String,String> trendReportMap = new LinkedHashMap<String, String>();
-
-
-    public static final String    COLLATE         = "Collate Results";
-    public static final String    COLLATE_ANALYZE = "Collate and Analyze";
-    public static final String    DO_NOTHING      = "Do Not Collate";
-    private static final String REGEX =  "^\\$\\{.*\\}$|^[0-9]*$"; // regex for parameter or numeric
-
+    public static final String COLLATE = "Collate Results";
+    public static final String COLLATE_ANALYZE = "Collate and Analyze";
+    public static final String DO_NOTHING = "Do Not Collate";
+    private static final String REGEX = "^\\$\\{.*\\}$|^[0-9]*$"; // regex for parameter or numeric
+    public Map<String, String> postRunActionMap = new LinkedHashMap<String, String>();
+    public Map<String, String> testInstanceMap = new LinkedHashMap<String, String>();
+    public Map<String, String> trendReportMap = new LinkedHashMap<String, String>();
     ArrayList<String> localDAtaArray = new ArrayList<String>();
 
     // Convert the params from the ui into a config map to be stored in the database for being used by the task.
-    public Map<String, String> generateTaskConfigMap(final ActionParametersMap params, final TaskDefinition previousTaskDefinition)
-    {
+    public Map<String, String> generateTaskConfigMap(final ActionParametersMap params, final TaskDefinition previousTaskDefinition) {
         final Map<String, String> config = super.generateTaskConfigMap(params, previousTaskDefinition);
 
         config.put(PC_SERVER, params.getString(PC_SERVER));
@@ -110,13 +105,13 @@ public class TaskConfigurator extends AbstractTaskConfigurator {
             String val = params.getString(p);
             if ((StringUtils.equals(p, TEST_INSTANCE_ID) && !StringUtils.equals(params.getString("TestInstanceIDRadio"), "AUTO"))
                     || StringUtils.equals(p, TEST_ID)
-                    || (StringUtils.equals(p, TREND_REPORT_ID) && StringUtils.equals(params.getString("trendingRadio"), "USE_ID"))){
+                    || (StringUtils.equals(p, TREND_REPORT_ID) && StringUtils.equals(params.getString("trendingRadio"), "USE_ID"))) {
                 if (StringUtils.isEmpty(val)) {
                     errorCollection.addError(p, "Required!");
-                }else if(!val.matches(REGEX)){
+                } else if (!val.matches(REGEX)) {
                     errorCollection.addError(p, "Must be numeric or a variable (e.g. ${value}).");
                 }
-            }else {
+            } else {
                 if (StringUtils.isEmpty(val) && !StringUtils.equals(p, PASSWORD) && !StringUtils.equals(p, TEST_INSTANCE_ID) && !StringUtils.equals(p, TREND_REPORT_ID)) {
                     errorCollection.addError(p, "Required!");
                 }
@@ -125,7 +120,7 @@ public class TaskConfigurator extends AbstractTaskConfigurator {
     }
 
     // array with parameters we want to validate
-    private void updateLocalArray(){
+    private void updateLocalArray() {
         localDAtaArray.clear();
 
         localDAtaArray.add(PC_SERVER);
@@ -141,28 +136,27 @@ public class TaskConfigurator extends AbstractTaskConfigurator {
         localDAtaArray.add(TREND_REPORT_ID);
         // localDAtaArray.add(POST_RUN_ACTION);
 
-        postRunActionMap.put(PostRunAction.DO_NOTHING.getValue().replaceAll(" ","_"), PostRunAction.DO_NOTHING.getValue()); //"Do Not Collate"
-        postRunActionMap.put(PostRunAction.COLLATE.getValue().replaceAll(" ","_"), PostRunAction.COLLATE.getValue()); // "Collate Results"
-        postRunActionMap.put(PostRunAction.COLLATE_AND_ANALYZE.getValue().replaceAll(" ","_"), PostRunAction.COLLATE_AND_ANALYZE.getValue()); //"Collate and Analyze")
+        postRunActionMap.put(PostRunAction.DO_NOTHING.getValue().replaceAll(" ", "_"), PostRunAction.DO_NOTHING.getValue()); //"Do Not Collate"
+        postRunActionMap.put(PostRunAction.COLLATE.getValue().replaceAll(" ", "_"), PostRunAction.COLLATE.getValue()); // "Collate Results"
+        postRunActionMap.put(PostRunAction.COLLATE_AND_ANALYZE.getValue().replaceAll(" ", "_"), PostRunAction.COLLATE_AND_ANALYZE.getValue()); //"Collate and Analyze")
 
-        testInstanceMap.put("AUTO","Automatically select existing or create new if none exists (Performance Center 12.55 or later)");
-        testInstanceMap.put("MANUAL","Manual selection");
+        testInstanceMap.put("AUTO", "Automatically select existing or create new if none exists (Performance Center 12.55 or later)");
+        testInstanceMap.put("MANUAL", "Manual selection");
 
-        trendReportMap.put("NO_TREND","Do Not Trend");
-        trendReportMap.put("ASSOCIATED","Use trend report associated with the test - Performance Center 12.55 or later");
-        trendReportMap.put("USE_ID","Add run to trend report with ID");
+        trendReportMap.put("NO_TREND", "Do Not Trend");
+        trendReportMap.put("ASSOCIATED", "Use trend report associated with the test - Performance Center 12.55 or later");
+        trendReportMap.put("USE_ID", "Add run to trend report with ID");
     }
 
 
     // Fill the saved data of the task when opening it after the last save
     @Override
-    public void populateContextForEdit(final Map<String, Object> context, final TaskDefinition taskDefinition)
-    {
+    public void populateContextForEdit(final Map<String, Object> context, final TaskDefinition taskDefinition) {
         updateLocalArray();
 
         context.put("postRunActionList", postRunActionMap);
-        context.put("testInstanceList",testInstanceMap);
-        context.put("trendReporList",trendReportMap);
+        context.put("testInstanceList", testInstanceMap);
+        context.put("trendReporList", trendReportMap);
 
         // context.put("selectedPostRunAction",taskDefinition.getConfiguration().get(POST_RUN_ACTION));
 
@@ -191,15 +185,14 @@ public class TaskConfigurator extends AbstractTaskConfigurator {
 
     // Fill the data of the task when opening it at the first time
     @Override
-    public void populateContextForCreate(final Map<String, Object> context)
-    {
+    public void populateContextForCreate(final Map<String, Object> context) {
         updateLocalArray();
         super.populateContextForCreate(context);
         context.put("postRunActionList", postRunActionMap);
-        context.put("testInstanceList",testInstanceMap);
-        context.put("trendReporList",trendReportMap);
+        context.put("testInstanceList", testInstanceMap);
+        context.put("trendReporList", trendReportMap);
 
-        context.put(TIMESLOT_HOURS,"0");
-        context.put(TIMESLOT_MINUTES,"30");
+        context.put(TIMESLOT_HOURS, "0");
+        context.put(TIMESLOT_MINUTES, "30");
     }
 }

--- a/src/main/java/com/adm/bamboo/plugin/performancecenter/TaskExecution.java
+++ b/src/main/java/com/adm/bamboo/plugin/performancecenter/TaskExecution.java
@@ -1,18 +1,18 @@
 /*
  * Certain versions of software and/or documents ("Material") accessible here may contain branding from
  * Hewlett-Packard Company (now HP Inc.) and Hewlett Packard Enterprise Company.  As of September 1, 2017,
- * the Material is now offered by Micro Focus, a separately owned and operated company.  Any reference to the HP
+ * the Material is now offered by Open Text Corporation, a separately owned and operated company.  Any reference to the HP
  * and Hewlett Packard Enterprise/HPE marks is historical in nature, and the HP and Hewlett Packard Enterprise/HPE
  * marks are the property of their respective owners.
  * __________________________________________________________________
  * MIT License
  *
- * (c) Copyright 2012-2019 Micro Focus or one of its affiliates.
+ * Copyright © 2023 Open Text Corporation
  *
- * The only warranties for products and services of Micro Focus and its affiliates
- * and licensors ("Micro Focus") are set forth in the express warranty statements
+ * The only warranties for products and services of Open Text Corporation
+ * are set forth in the express warranty statements
  * accompanying such products and services. Nothing herein should be construed as
- * constituting an additional warranty. Micro Focus shall not be liable for technical
+ * constituting an additional warranty. Open Text shall not be liable for technical
  * or editorial errors or omissions contained herein.
  * The information contained herein is subject to change without notice.
  * ___________________________________________________________________
@@ -21,9 +21,10 @@
 package com.adm.bamboo.plugin.performancecenter;
 
 import com.adm.bamboo.plugin.performancecenter.impl.PcComponentsImpl;
-import com.microfocus.adm.performancecenter.plugins.common.pcentities.*;
 import com.atlassian.bamboo.build.logger.BuildLogger;
 import com.atlassian.bamboo.task.*;
+import com.microfocus.adm.performancecenter.plugins.common.pcentities.PcException;
+import com.microfocus.adm.performancecenter.plugins.common.pcentities.PostRunAction;
 
 import java.io.IOException;
 
@@ -31,13 +32,10 @@ import java.io.IOException;
 /**
  * Created by bemh on 7/23/2017.
  */
-public class TaskExecution implements TaskType
-{
+public class TaskExecution implements TaskType {
 
     @Override
-    public TaskResult execute(final TaskContext taskContext) throws TaskException
-    {
-
+    public TaskResult execute(final TaskContext taskContext) throws TaskException {
 
 
         final BuildLogger buildLogger = taskContext.getBuildLogger();
@@ -50,7 +48,7 @@ public class TaskExecution implements TaskType
         final String TEST_ID = taskContext.getConfigurationMap().get(TaskConfigurator.TEST_ID);
         final String TEST_INSTANCE_ID_RADIO = taskContext.getConfigurationMap().get(TaskConfigurator.TEST_INSTANCE_ID_RADIO);
         final String TEST_INSTANCE_ID = taskContext.getConfigurationMap().get(TaskConfigurator.TEST_INSTANCE_ID);
-        final String LOCAL_PROXY  = taskContext.getConfigurationMap().get(TaskConfigurator.LOCAL_PROXY);
+        final String LOCAL_PROXY = taskContext.getConfigurationMap().get(TaskConfigurator.LOCAL_PROXY);
         final String PROXY_USER = taskContext.getConfigurationMap().get(TaskConfigurator.PROXY_USER);
         final String PROXY_PASSWORD = taskContext.getConfigurationMap().get(TaskConfigurator.PROXY_PASSWORD);
         final String POST_RUN_ACTION = taskContext.getConfigurationMap().get(TaskConfigurator.POST_RUN_ACTION);
@@ -65,7 +63,7 @@ public class TaskExecution implements TaskType
         String runID;
 
 
-        PcComponentsImpl r = new PcComponentsImpl(taskContext,buildLogger,PC_SERVER,USER,PASSWORD,DOMAIN,PROJECT,TEST_ID,TEST_INSTANCE_ID_RADIO,TEST_INSTANCE_ID,TIMESLOT_HOURS,TIMESLOT_MINUTES, convertStringBackToPostRunAction(POST_RUN_ACTION),Boolean.parseBoolean(VUDS),Boolean.parseBoolean(SLA),"",TRENDING_RADIO,TREND_REPORT_ID,Boolean.parseBoolean(HTTPS),LOCAL_PROXY,PROXY_USER,PROXY_PASSWORD, Boolean.parseBoolean(AUTHENTICATE_WITH_TOKEN));
+        PcComponentsImpl r = new PcComponentsImpl(taskContext, buildLogger, PC_SERVER, USER, PASSWORD, DOMAIN, PROJECT, TEST_ID, TEST_INSTANCE_ID_RADIO, TEST_INSTANCE_ID, TIMESLOT_HOURS, TIMESLOT_MINUTES, convertStringBackToPostRunAction(POST_RUN_ACTION), Boolean.parseBoolean(VUDS), Boolean.parseBoolean(SLA), "", TRENDING_RADIO, TREND_REPORT_ID, Boolean.parseBoolean(HTTPS), LOCAL_PROXY, PROXY_USER, PROXY_PASSWORD, Boolean.parseBoolean(AUTHENTICATE_WITH_TOKEN));
 
 
         try {
@@ -74,21 +72,20 @@ public class TaskExecution implements TaskType
             buildLogger.addBuildLogEntry("Executing Load Test:");
             buildLogger.addBuildLogEntry("====================");
             buildLogger.addBuildLogEntry("Test ID:" + TEST_ID);
-            if("AUTO".equals(TEST_INSTANCE_ID_RADIO)){
+            if ("AUTO".equals(TEST_INSTANCE_ID_RADIO)) {
                 buildLogger.addBuildLogEntry("Test Instance ID:" + TEST_INSTANCE_ID_RADIO);
-            }else{
+            } else {
                 buildLogger.addBuildLogEntry("Test Instance ID:" + TEST_INSTANCE_ID);
             }
             buildLogger.addBuildLogEntry("Timeslot Duration::" + TIMESLOT_HOURS + ":" + TIMESLOT_MINUTES + " (h:mm)");
             buildLogger.addBuildLogEntry("Post Run Action:" + POST_RUN_ACTION);
-            buildLogger.addBuildLogEntry("Use VUDS:" + ("true".equals(VUDS.toLowerCase())?"true":"false"));
+            buildLogger.addBuildLogEntry("Use VUDS:" + ("true".equals(VUDS.toLowerCase()) ? "true" : "false"));
 
             buildLogger.addBuildLogEntry("====================");
             runID = r.startRun();
             buildLogger.addBuildLogEntry("====================");
 
-            if(Boolean.parseBoolean(SLA) == true && !r.isSlaStatusPassed())
-            {
+            if (Boolean.parseBoolean(SLA) == true && !r.isSlaStatusPassed()) {
                 buildLogger.addErrorLogEntry("Run measurements did not reach SLA criteria. Run SLA Status: " + r.getRunSLAStatus());
                 return TaskResultBuilder.newBuilder(taskContext).failed().build();
             }
@@ -111,17 +108,15 @@ public class TaskExecution implements TaskType
     }
 
 
-
-    private PostRunAction convertStringBackToPostRunAction(String postRunAction){
-        for(PostRunAction p: PostRunAction.values()){
-            if(postRunAction.replaceAll("_"," ").equals(p.getValue())){
+    private PostRunAction convertStringBackToPostRunAction(String postRunAction) {
+        for (PostRunAction p : PostRunAction.values()) {
+            if (postRunAction.replaceAll("_", " ").equals(p.getValue())) {
                 return p;
             }
         }
         return PostRunAction.DO_NOTHING;
 
     }
-
 
 
 }

--- a/src/main/java/com/adm/bamboo/plugin/performancecenter/TaskExecution.java
+++ b/src/main/java/com/adm/bamboo/plugin/performancecenter/TaskExecution.java
@@ -1,22 +1,22 @@
 /*
- * Certain versions of software and/or documents ("Material") accessible here may contain branding from
- * Hewlett-Packard Company (now HP Inc.) and Hewlett Packard Enterprise Company.  As of September 1, 2017,
- * the Material is now offered by Open Text Corporation, a separately owned and operated company.  Any reference to the HP
- * and Hewlett Packard Enterprise/HPE marks is historical in nature, and the HP and Hewlett Packard Enterprise/HPE
- * marks are the property of their respective owners.
- * __________________________________________________________________
- * MIT License
- *
- * Copyright © 2023 Open Text Corporation
- *
- * The only warranties for products and services of Open Text Corporation
- * are set forth in the express warranty statements
- * accompanying such products and services. Nothing herein should be construed as
- * constituting an additional warranty. Open Text shall not be liable for technical
- * or editorial errors or omissions contained herein.
- * The information contained herein is subject to change without notice.
- * ___________________________________________________________________
- */
+* Certain versions of software and/or documents ("Material") accessible here may contain branding from
+* Hewlett-Packard Company (now HP Inc.) and Hewlett Packard Enterprise Company.
+* The Material is now offered by Open Text Corporation, a separately owned and operated company.  Any reference to the HP
+* and Hewlett Packard Enterprise/HPE marks is historical in nature, and the HP and Hewlett Packard Enterprise/HPE
+* marks are the property of their respective owners.
+* __________________________________________________________________
+* MIT License
+*
+* Copyright © 2023 Open Text Corporation
+*
+* The only warranties for products and services of Open Text Corporation
+* are set forth in the express warranty statements
+* accompanying such products and services. Nothing herein should be construed as
+* constituting an additional warranty. Open Text shall not be liable for technical
+* or editorial errors or omissions contained herein.
+* The information contained herein is subject to change without notice.
+* ___________________________________________________________________
+*/
 
 package com.adm.bamboo.plugin.performancecenter;
 

--- a/src/main/java/com/adm/bamboo/plugin/performancecenter/impl/PcClientBamboo.java
+++ b/src/main/java/com/adm/bamboo/plugin/performancecenter/impl/PcClientBamboo.java
@@ -1,18 +1,18 @@
 /*
  * Certain versions of software and/or documents ("Material") accessible here may contain branding from
  * Hewlett-Packard Company (now HP Inc.) and Hewlett Packard Enterprise Company.  As of September 1, 2017,
- * the Material is now offered by Micro Focus, a separately owned and operated company.  Any reference to the HP
+ * the Material is now offered by Open Text Corporation, a separately owned and operated company.  Any reference to the HP
  * and Hewlett Packard Enterprise/HPE marks is historical in nature, and the HP and Hewlett Packard Enterprise/HPE
  * marks are the property of their respective owners.
  * __________________________________________________________________
  * MIT License
  *
- * (c) Copyright 2012-2019 Micro Focus or one of its affiliates.
+ * Copyright © 2023 Open Text Corporation
  *
- * The only warranties for products and services of Micro Focus and its affiliates
- * and licensors ("Micro Focus") are set forth in the express warranty statements
+ * The only warranties for products and services of Open Text Corporation
+ * are set forth in the express warranty statements
  * accompanying such products and services. Nothing herein should be construed as
- * constituting an additional warranty. Micro Focus shall not be liable for technical
+ * constituting an additional warranty. Open Text shall not be liable for technical
  * or editorial errors or omissions contained herein.
  * The information contained herein is subject to change without notice.
  * ___________________________________________________________________
@@ -23,8 +23,10 @@ package com.adm.bamboo.plugin.performancecenter.impl;
 import com.atlassian.bamboo.build.logger.BuildLogger;
 import com.atlassian.bamboo.plan.artifact.ArtifactDefinitionContextImpl;
 import com.atlassian.bamboo.task.TaskContext;
-import org.apache.commons.io.IOUtils;
+import com.microfocus.adm.performancecenter.plugins.common.pcentities.*;
+import com.microfocus.adm.performancecenter.plugins.common.rest.PcRestProxy;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.http.client.ClientProtocolException;
 
 import java.beans.IntrospectionException;
@@ -37,53 +39,48 @@ import java.util.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-//import org.hibernate.cfg.beanvalidation.IntegrationException;
-
-import com.microfocus.adm.performancecenter.plugins.common.rest.*;
-import com.microfocus.adm.performancecenter.plugins.common.pcentities.*;
-
 /**
  * Created by bemh on 8/6/2017.
  */
 public class PcClientBamboo {
 
 
-    private static final String artifactsDirectoryName = "archive";
     public static final String artifactsResourceName = "artifact";
     public static final String runReportStructure = "%s/%s/performanceTestsReports/pcRun";
     public static final String trendReportStructure = "%s/%s/performanceTestsReports/TrendReports";
     public static final String pcReportArchiveName = "Reports.zip";
     public static final String pcReportFileName = "Report.html";
+    public static final String TRENDED = "Trended";
+    public static final String PENDING = "Pending";
+    public static final String PUBLISHING = "Publishing";
+    public static final String ERROR = "Error";
+    public static final String COLLATE = "COLLATE";
+    public static final String COLLATE_ANALYZE = "COLLATE_AND_ANALYZE";
+    public static final String DO_NOTHING = "DO_NOTHING";
+    private static final String artifactsDirectoryName = "archive";
     private static final String RUNID_BUILD_VARIABLE = "HP_RUN_ID";
-
-    public static final String    TRENDED         = "Trended";
-    public static final String    PENDING         = "Pending";
-    public static final String    PUBLISHING      = "Publishing";
-    public static final String    ERROR           = "Error";
-
+    /**
+     * Size of the buffer to read/write data
+     */
+    private static final int BUFFER_SIZE = 4096;
     private PcModelBamboo model;
     private TaskContext taskContext;
     private PcRestProxy restProxy;
     private boolean loggedIn;
     private BuildLogger buildLogger;
-
     private PrintStream ps;
-
-    public static final String    COLLATE         = "COLLATE";
-    public static final String    COLLATE_ANALYZE = "COLLATE_AND_ANALYZE";
-    public static final String    DO_NOTHING      = "DO_NOTHING";
 
     public PcClientBamboo(PcModelBamboo pcModel, TaskContext taskContext, BuildLogger buildLogger) {
         try {
             model = pcModel;
             this.taskContext = taskContext;
 
-            if(model.getProxyOutURL() != null && !model.getProxyOutURL().isEmpty()){
+            if (model.getProxyOutURL() != null && !model.getProxyOutURL().isEmpty()) {
                 buildLogger.addBuildLogEntry("Using proxy: " + model.getProxyOutURL());
             }
-            restProxy = new PcRestProxy(model.isHTTPSProtocol(),model.getPcServerName(), model.isAuthenticateWithToken(), model.getAlmDomain(), model.getAlmProject(), model.getProxyOutURL(),model.getProxyOutUser(),model.getProxyOutPassword());
+            restProxy = new PcRestProxy(model.isHTTPSProtocol(), model.getPcServerName(), model.isAuthenticateWithToken(), model.getAlmDomain(), model.getAlmProject(), model.getProxyOutURL(), model.getProxyOutUser(), model.getProxyOutPassword());
             this.buildLogger = buildLogger;
-        }catch (PcException e){
+        } catch (PcException e) {
             buildLogger.addBuildLogEntry(e.getMessage());
         }
 
@@ -92,7 +89,7 @@ public class PcClientBamboo {
     public boolean login() {
         try {
             String user = model.getAlmUserName();
-            buildLogger.addBuildLogEntry(String.format("Trying to login LRE Server '%s://%s/%s' with credentials of %s '%s']",model.isHTTPSProtocol(), restProxy.GetPcServer(), restProxy.GetTenant(), model.isAuthenticateWithToken() ? "ClientIdKey" : "User" ,user));
+            buildLogger.addBuildLogEntry(String.format("Trying to login LRE Server '%s://%s/%s' with credentials of %s '%s']", model.isHTTPSProtocol(), restProxy.GetPcServer(), restProxy.GetTenant(), model.isAuthenticateWithToken() ? "ClientIdKey" : "User", user));
             loggedIn = restProxy.authenticate(user, model.getAlmPassword());
         } catch (PcException e) {
             buildLogger.addBuildLogEntry(e.getMessage());
@@ -102,7 +99,6 @@ public class PcClientBamboo {
         buildLogger.addBuildLogEntry(String.format("Login %s", loggedIn ? "succeeded" : "failed"));
         return loggedIn;
     }
-
 
     public boolean isLoggedIn() {
         return loggedIn;
@@ -117,44 +113,44 @@ public class PcClientBamboo {
                 testInstance,
                 model.getTimeslotDuration(),
                 model.getPostRunAction().getValue(),
-                model.isVudsMode());
-       buildLogger.addBuildLogEntry(String.format("\nRun started (TestID: %s, RunID: %s, TimeslotID: %s)\n",
+                model.isVudsMode(), 0);
+        buildLogger.addBuildLogEntry(String.format("\nRun started (TestID: %s, RunID: %s, TimeslotID: %s)\n",
                 response.getTestID(), response.getID(), response.getTimeslotID()));
         return response.getID();
     }
 
     private int getCorrectTestInstanceID(int testID) throws IOException, PcException {
-        if("AUTO".equals(model.getAutoTestInstanceID())){
+        if ("AUTO".equals(model.getAutoTestInstanceID())) {
             try {
 
 
-               buildLogger.addBuildLogEntry("Searching for available Test Instance");
+                buildLogger.addBuildLogEntry("Searching for available Test Instance");
                 PcTestInstances pcTestInstances = restProxy.getTestInstancesByTestId(testID);
                 int testInstanceID = 0;
-                if (pcTestInstances != null && pcTestInstances.getTestInstancesList() != null){
-                    PcTestInstance pcTestInstance = pcTestInstances.getTestInstancesList().get(pcTestInstances.getTestInstancesList().size()-1);
+                if (pcTestInstances != null && pcTestInstances.getTestInstancesList() != null) {
+                    PcTestInstance pcTestInstance = pcTestInstances.getTestInstancesList().get(pcTestInstances.getTestInstancesList().size() - 1);
                     testInstanceID = pcTestInstance.getInstanceId();
-                   buildLogger.addBuildLogEntry("Found testInstanceId: " + testInstanceID);
-                }else{
-                   buildLogger.addBuildLogEntry("Could not find available TestInstanceID, Creating Test Instance.");
-                   buildLogger.addBuildLogEntry("Searching for available TestSet");
+                    buildLogger.addBuildLogEntry("Found testInstanceId: " + testInstanceID);
+                } else {
+                    buildLogger.addBuildLogEntry("Could not find available TestInstanceID, Creating Test Instance.");
+                    buildLogger.addBuildLogEntry("Searching for available TestSet");
                     // Get a random TestSet
                     PcTestSets pcTestSets = restProxy.GetAllTestSets();
-                    if (pcTestSets !=null && pcTestSets.getPcTestSetsList() !=null){
-                        PcTestSet pcTestSet = pcTestSets.getPcTestSetsList().get(pcTestSets.getPcTestSetsList().size()-1);
+                    if (pcTestSets != null && pcTestSets.getPcTestSetsList() != null) {
+                        PcTestSet pcTestSet = pcTestSets.getPcTestSetsList().get(pcTestSets.getPcTestSetsList().size() - 1);
                         int testSetID = pcTestSet.getTestSetID();
-                       buildLogger.addBuildLogEntry(String.format("Creating Test Instance with testID: %s and TestSetID: %s", testID,testSetID));
-                        testInstanceID = restProxy.createTestInstance(testID,testSetID);
-                       buildLogger.addBuildLogEntry(String.format("Test Instance with ID : %s has been created successfully.", testInstanceID));
-                    }else{
+                        buildLogger.addBuildLogEntry(String.format("Creating Test Instance with testID: %s and TestSetID: %s", testID, testSetID));
+                        testInstanceID = restProxy.createTestInstance(testID, testSetID);
+                        buildLogger.addBuildLogEntry(String.format("Test Instance with ID : %s has been created successfully.", testInstanceID));
+                    } else {
                         String msg = "No TestSetID available in project, please create a TestSet from LoadRunner Enterprise UI";
-                       buildLogger.addBuildLogEntry(msg);
+                        buildLogger.addBuildLogEntry(msg);
                         throw new PcException(msg);
                     }
                 }
                 return testInstanceID;
-            } catch (Exception e){
-                throw new PcException(String.format("getCorrectTestInstanceID failed, reason: %s",e));
+            } catch (Exception e) {
+                throw new PcException(String.format("getCorrectTestInstanceID failed, reason: %s", e));
             }
         }
         return Integer.parseInt(model.getTestInstanceId());
@@ -162,11 +158,11 @@ public class PcClientBamboo {
 
     private void setCorrectTrendReportID() throws IOException, PcException {
         // If the user selected "Use trend report associated with the test" we want the report ID to be the one from the test
-        if (("ASSOCIATED").equals(model.getAddRunToTrendReport())){
+        if (("ASSOCIATED").equals(model.getAddRunToTrendReport())) {
             PcTest pcTest = restProxy.getTestData(Integer.parseInt(model.getTestId()));
             if (pcTest.getTrendReportId() > -1)
                 model.setTrendReportId(String.valueOf(pcTest.getTrendReportId()));
-            else{
+            else {
                 String msg = "No trend report ID is associated with the test.\n" +
                         "Please turn Automatic Trending on for the test through LoadRunner Enterprise UI.\n" +
                         "Alternatively you can check 'Add run to trend report with ID' on configuration dialog.";
@@ -176,7 +172,7 @@ public class PcClientBamboo {
 
     }
 
-    public String getTestName()  throws IOException, PcException{
+    public String getTestName() throws IOException, PcException {
         PcTest pcTest = restProxy.getTestData(Integer.parseInt(model.getTestId()));
         return pcTest.getTestName();
     }
@@ -201,12 +197,11 @@ public class PcClientBamboo {
         return waitForRunState(runId, state, interval);
     }
 
-
     private PcRunResponse waitForRunState(int runId, RunState completionState, int interval) throws InterruptedException,
             ClientProtocolException, PcException, IOException {
 
         int counter = 0;
-        RunState[] states = {RunState.BEFORE_COLLATING_RESULTS,RunState.BEFORE_CREATING_ANALYSIS_DATA};
+        RunState[] states = {RunState.BEFORE_COLLATING_RESULTS, RunState.BEFORE_CREATING_ANALYSIS_DATA};
         PcRunResponse response = null;
         RunState lastState = RunState.UNDEFINED;
         do {
@@ -214,19 +209,19 @@ public class PcClientBamboo {
             RunState currentState = RunState.get(response.getRunState());
             if (lastState.ordinal() < currentState.ordinal()) {
                 lastState = currentState;
-               buildLogger.addBuildLogEntry(String.format("RunID: %s - State = %s", runId, currentState.value()));
+                buildLogger.addBuildLogEntry(String.format("RunID: %s - State = %s", runId, currentState.value()));
             }
 
             // In case we are in state before collate or before analyze, we will wait 1 minute for the state to change otherwise we exit
             // because the user probably stopped the run from PC or timeslot has reached the end.
-            if (Arrays.asList(states).contains(currentState)){
+            if (Arrays.asList(states).contains(currentState)) {
                 counter++;
                 Thread.sleep(1000);
-                if(counter > 60 ){
-                   buildLogger.addBuildLogEntry(String.format("RunID: %s  - Stopped from LoadRunner Enterprise side with state = %s", runId, currentState.value()));
+                if (counter > 60) {
+                    buildLogger.addBuildLogEntry(String.format("RunID: %s  - Stopped from LoadRunner Enterprise side with state = %s", runId, currentState.value()));
                     break;
                 }
-            }else{
+            } else {
                 counter = 0;
                 Thread.sleep(interval);
             }
@@ -238,36 +233,35 @@ public class PcClientBamboo {
 
 
         PcRunResults runResultsList = restProxy.getRunResults(runId);
-        if (runResultsList.getResultsList() != null){
+        if (runResultsList.getResultsList() != null) {
             for (PcRunResult result : runResultsList.getResultsList()) {
                 if (result.getName().equals(pcReportArchiveName)) {
-                    File dir = new File(reportDirectory  + File.separator + "Reports");// taskContext.getBuildContext().getBuildNumber());
+                    File dir = new File(reportDirectory + File.separator + "Reports");// taskContext.getBuildContext().getBuildNumber());
                     dir.mkdirs();
                     String reportArchiveFullPath = dir.getCanonicalPath() + IOUtils.DIR_SEPARATOR + pcReportArchiveName;
                     buildLogger.addBuildLogEntry("Publishing analysis report");
                     restProxy.GetRunResultData(runId, result.getID(), reportArchiveFullPath);
                     File fp = new File(reportArchiveFullPath);
-                    unzip(reportArchiveFullPath,fp.getParent().toString());
+                    unzip(reportArchiveFullPath, fp.getParent().toString());
                     String reportFile = dir.getPath() + File.separator + pcReportFileName;
                     publishHTMLReportToArtifact();
                     //Deleting the unziped report file
-                  //  FileUtils.deleteDirectory(dir);
+                    //  FileUtils.deleteDirectory(dir);
                     return reportFile;
                 }
             }
         }
-       buildLogger.addBuildLogEntry("Failed to get run report");
+        buildLogger.addBuildLogEntry("Failed to get run report");
         return null;
     }
 
-    public void publishHTMLReportToArtifact(){
+    public void publishHTMLReportToArtifact() {
         Map<String, String> config = new HashMap<>();
 
-        ArtifactDefinitionContextImpl artifact = new ArtifactDefinitionContextImpl("Build_" + String.valueOf(taskContext.getBuildContext().getBuildNumber()) + "_reports",false,null);
+        ArtifactDefinitionContextImpl artifact = new ArtifactDefinitionContextImpl("Build_" + String.valueOf(taskContext.getBuildContext().getBuildNumber()) + "_reports", false, null);
         artifact.setCopyPattern("**/*");
         taskContext.getBuildContext().getArtifactContext().getDefinitionContexts().add(artifact);
     }
-
 
     public boolean logout() {
         if (!loggedIn)
@@ -278,57 +272,54 @@ public class PcClientBamboo {
             logoutSucceeded = restProxy.logout();
             loggedIn = !logoutSucceeded;
         } catch (PcException e) {
-           buildLogger.addBuildLogEntry(e.getMessage());
+            buildLogger.addBuildLogEntry(e.getMessage());
         } catch (Exception e) {
-           buildLogger.addBuildLogEntry(String.valueOf(e));
+            buildLogger.addBuildLogEntry(String.valueOf(e));
         }
-       buildLogger.addBuildLogEntry(String.format("Logout %s", logoutSucceeded ? "succeeded" : "failed"));
+        buildLogger.addBuildLogEntry(String.format("Logout %s", logoutSucceeded ? "succeeded" : "failed"));
         return logoutSucceeded;
     }
 
     public boolean stopRun(int runId) {
         boolean stopRunSucceeded = false;
         try {
-           buildLogger.addBuildLogEntry("Stopping run");
+            buildLogger.addBuildLogEntry("Stopping run");
             stopRunSucceeded = restProxy.stopRun(runId, "stop");
         } catch (PcException e) {
-           buildLogger.addBuildLogEntry(e.getMessage());
+            buildLogger.addBuildLogEntry(e.getMessage());
         } catch (Exception e) {
-           buildLogger.addBuildLogEntry(String.valueOf(e));
+            buildLogger.addBuildLogEntry(String.valueOf(e));
         }
-       buildLogger.addBuildLogEntry(String.format("Stop run %s", stopRunSucceeded ? "succeeded" : "failed"));
+        buildLogger.addBuildLogEntry(String.format("Stop run %s", stopRunSucceeded ? "succeeded" : "failed"));
         return stopRunSucceeded;
     }
 
-    public PcRunEventLog getRunEventLog(int runId){
+    public PcRunEventLog getRunEventLog(int runId) {
         try {
             return restProxy.getRunEventLog(runId);
         } catch (PcException e) {
-           buildLogger.addBuildLogEntry(e.getMessage());
+            buildLogger.addBuildLogEntry(e.getMessage());
         } catch (Exception e) {
-           buildLogger.addBuildLogEntry(String.valueOf(e));
+            buildLogger.addBuildLogEntry(String.valueOf(e));
         }
         return null;
     }
 
-    public void addRunToTrendReport(int runId, String trendReportId)
-    {
+    public void addRunToTrendReport(int runId, String trendReportId) {
 
         TrendReportRequest trRequest = new TrendReportRequest(model.getAlmProject(), runId, null);
-       buildLogger.addBuildLogEntry("Adding run: " + runId + " to trend report: " + trendReportId);
+        buildLogger.addBuildLogEntry("Adding run: " + runId + " to trend report: " + trendReportId);
         try {
             restProxy.updateTrendReport(trendReportId, trRequest);
-           buildLogger.addBuildLogEntry("Publishing run: " + runId + " on trend report: " + trendReportId);
-        }
-        catch (PcException e) {
-           buildLogger.addBuildLogEntry("Failed to add run to trend report: " + e.getMessage());
-        }
-        catch (IOException e) {
-           buildLogger.addBuildLogEntry("Failed to add run to trend report: Problem connecting to PC Server");
+            buildLogger.addBuildLogEntry("Publishing run: " + runId + " on trend report: " + trendReportId);
+        } catch (PcException e) {
+            buildLogger.addBuildLogEntry("Failed to add run to trend report: " + e.getMessage());
+        } catch (IOException e) {
+            buildLogger.addBuildLogEntry("Failed to add run to trend report: Problem connecting to PC Server");
         }
     }
 
-    public void waitForRunToPublishOnTrendReport(int runId, String trendReportId) throws PcException,IOException,InterruptedException{
+    public void waitForRunToPublishOnTrendReport(int runId, String trendReportId) throws PcException, IOException, InterruptedException {
 
         ArrayList<PcTrendedRun> trendReportMetaDataResultsList;
         boolean publishEnded = false;
@@ -337,38 +328,33 @@ public class PcClientBamboo {
         do {
             trendReportMetaDataResultsList = restProxy.getTrendReportMetaData(trendReportId);
 
-            if (trendReportMetaDataResultsList.isEmpty())  break;
+            if (trendReportMetaDataResultsList.isEmpty()) break;
 
             for (PcTrendedRun result : trendReportMetaDataResultsList) {
 
                 if (result.getRunID() != runId) continue;
 
-                if (result.getState().equals(TRENDED) || result.getState().equals(ERROR)){
+                if (result.getState().equals(TRENDED) || result.getState().equals(ERROR)) {
                     publishEnded = true;
-                   buildLogger.addBuildLogEntry("Run: " + runId + " publishing status: "+ result.getState());
+                    buildLogger.addBuildLogEntry("Run: " + runId + " publishing status: " + result.getState());
                     break;
-                }else{
+                } else {
                     Thread.sleep(5000);
                     counter++;
-                    if(counter >= 120){
+                    if (counter >= 120) {
                         String msg = "Error: Publishing didn't ended after 10 minutes, aborting...";
                         throw new PcException(msg);
                     }
                 }
             }
 
-        }while (!publishEnded && counter < 120);
+        } while (!publishEnded && counter < 120);
     }
 
-
-
-    /**
-     * Size of the buffer to read/write data
-     */
-    private static final int BUFFER_SIZE = 4096;
     /**
      * Extracts a zip file specified by the zipFilePath to a directory specified by
      * destDirectory (will be created if does not exists)
+     *
      * @param zipFilePath
      * @param destDirectory
      * @throws IOException
@@ -396,8 +382,10 @@ public class PcClientBamboo {
         }
         zipIn.close();
     }
+
     /**
      * Extracts a zip entry (file entry)
+     *
      * @param zipIn
      * @param filePath
      * @throws IOException
@@ -413,38 +401,34 @@ public class PcClientBamboo {
     }
 
 
-
     public boolean downloadTrendReportAsPdf(String trendReportId, String directory) throws PcException {
 
 
         try {
-           buildLogger.addBuildLogEntry("Downloading trend report: " + trendReportId + " in PDF format");
+            buildLogger.addBuildLogEntry("Downloading trend report: " + trendReportId + " in PDF format");
             InputStream in = restProxy.getTrendingPDF(trendReportId);
             File dir = new File(directory);
-            if(!dir.exists()){
+            if (!dir.exists()) {
                 dir.mkdirs();
-            }else{
+            } else {
                 FileUtils.deleteDirectory(dir);
                 dir.mkdirs();
             }
             String filePath = directory + IOUtils.DIR_SEPARATOR + "trendReport" + trendReportId + ".pdf";
             Path destination = Paths.get(filePath);
             Files.copy(in, destination, StandardCopyOption.REPLACE_EXISTING);
-           buildLogger.addBuildLogEntry("Trend report: " + trendReportId + " was successfully downloaded");
-           buildLogger.addBuildLogEntry("View trend report in the Artifacts Tab.");
+            buildLogger.addBuildLogEntry("Trend report: " + trendReportId + " was successfully downloaded");
+            buildLogger.addBuildLogEntry("View trend report in the Artifacts Tab.");
 
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
 
-           buildLogger.addBuildLogEntry("Failed to download trend report: " + e.getMessage());
+            buildLogger.addBuildLogEntry("Failed to download trend report: " + e.getMessage());
             throw new PcException(e.getMessage());
         }
 
         return true;
 
     }
-
-
 
 
     // This method will return a map with the following structure: <transaction_name:selected_measurement_value>
@@ -455,34 +439,30 @@ public class PcClientBamboo {
     public Map<String, String> getTrendReportByXML(String trendReportId, int runId, TrendReportTypes.DataType dataType, TrendReportTypes.PctType pctType, TrendReportTypes.Measurement measurement) throws IOException, PcException, IntrospectionException, NoSuchMethodException {
 
         Map<String, String> measurmentsMap = new LinkedHashMap<String, String>();
-        measurmentsMap.put("RunId","_" + runId + "_");
-        measurmentsMap.put("Trend Measurement Type",measurement.toString() + "_" + pctType.toString());
-
+        measurmentsMap.put("RunId", "_" + runId + "_");
+        measurmentsMap.put("Trend Measurement Type", measurement.toString() + "_" + pctType.toString());
 
 
         TrendReportTransactionDataRoot res = restProxy.getTrendReportByXML(trendReportId, runId);
 
         List<Object> RowsListObj = res.getTrendReportRoot();
 
-        for (int i=0; i< RowsListObj.size();i++){
+        for (int i = 0; i < RowsListObj.size(); i++) {
             try {
 
                 java.lang.reflect.Method rowListMethod = RowsListObj.get(i).getClass().getMethod("getTrendReport" + dataType.toString() + "DataRowList");
 
-                for ( Object DataRowObj : (ArrayList<Object>)rowListMethod.invoke(RowsListObj.get(i)))
-                {
-                    if (DataRowObj.getClass().getMethod("getPCT_TYPE").invoke(DataRowObj).equals(pctType.toString()))
-                    {
+                for (Object DataRowObj : (ArrayList<Object>) rowListMethod.invoke(RowsListObj.get(i))) {
+                    if (DataRowObj.getClass().getMethod("getPCT_TYPE").invoke(DataRowObj).equals(pctType.toString())) {
                         java.lang.reflect.Method method;
                         method = DataRowObj.getClass().getMethod("get" + measurement.toString());
-                        measurmentsMap.put(DataRowObj.getClass().getMethod("getPCT_NAME").invoke(DataRowObj).toString(),method.invoke(DataRowObj)==null?"":method.invoke(DataRowObj).toString());
+                        measurmentsMap.put(DataRowObj.getClass().getMethod("getPCT_NAME").invoke(DataRowObj).toString(), method.invoke(DataRowObj) == null ? "" : method.invoke(DataRowObj).toString());
                     }
                 }
-            }catch (NoSuchMethodException e){
+            } catch (NoSuchMethodException e) {
                 // buildLogger.addBuildLogEntry("No such method exception: " + e);
-            }
-            catch (Exception e){
-               buildLogger.addBuildLogEntry("Error on getTrendReportByXML: " + e);
+            } catch (Exception e) {
+                buildLogger.addBuildLogEntry("Error on getTrendReportByXML: " + e);
             }
         }
 

--- a/src/main/java/com/adm/bamboo/plugin/performancecenter/impl/PcClientBamboo.java
+++ b/src/main/java/com/adm/bamboo/plugin/performancecenter/impl/PcClientBamboo.java
@@ -1,22 +1,22 @@
 /*
- * Certain versions of software and/or documents ("Material") accessible here may contain branding from
- * Hewlett-Packard Company (now HP Inc.) and Hewlett Packard Enterprise Company.  As of September 1, 2017,
- * the Material is now offered by Open Text Corporation, a separately owned and operated company.  Any reference to the HP
- * and Hewlett Packard Enterprise/HPE marks is historical in nature, and the HP and Hewlett Packard Enterprise/HPE
- * marks are the property of their respective owners.
- * __________________________________________________________________
- * MIT License
- *
- * Copyright © 2023 Open Text Corporation
- *
- * The only warranties for products and services of Open Text Corporation
- * are set forth in the express warranty statements
- * accompanying such products and services. Nothing herein should be construed as
- * constituting an additional warranty. Open Text shall not be liable for technical
- * or editorial errors or omissions contained herein.
- * The information contained herein is subject to change without notice.
- * ___________________________________________________________________
- */
+* Certain versions of software and/or documents ("Material") accessible here may contain branding from
+* Hewlett-Packard Company (now HP Inc.) and Hewlett Packard Enterprise Company.
+* The Material is now offered by Open Text Corporation, a separately owned and operated company.  Any reference to the HP
+* and Hewlett Packard Enterprise/HPE marks is historical in nature, and the HP and Hewlett Packard Enterprise/HPE
+* marks are the property of their respective owners.
+* __________________________________________________________________
+* MIT License
+*
+* Copyright © 2023 Open Text Corporation
+*
+* The only warranties for products and services of Open Text Corporation
+* are set forth in the express warranty statements
+* accompanying such products and services. Nothing herein should be construed as
+* constituting an additional warranty. Open Text shall not be liable for technical
+* or editorial errors or omissions contained herein.
+* The information contained herein is subject to change without notice.
+* ___________________________________________________________________
+*/
 
 package com.adm.bamboo.plugin.performancecenter.impl;
 

--- a/src/main/java/com/adm/bamboo/plugin/performancecenter/impl/PcComponentsImpl.java
+++ b/src/main/java/com/adm/bamboo/plugin/performancecenter/impl/PcComponentsImpl.java
@@ -1,22 +1,22 @@
 /*
- * Certain versions of software and/or documents ("Material") accessible here may contain branding from
- * Hewlett-Packard Company (now HP Inc.) and Hewlett Packard Enterprise Company.  As of September 1, 2017,
- * the Material is now offered by Open Text Corporation, a separately owned and operated company.  Any reference to the HP
- * and Hewlett Packard Enterprise/HPE marks is historical in nature, and the HP and Hewlett Packard Enterprise/HPE
- * marks are the property of their respective owners.
- * __________________________________________________________________
- * MIT License
- *
- * Copyright © 2023 Open Text Corporation
- *
- * The only warranties for products and services of Open Text Corporation
- * are set forth in the express warranty statements
- * accompanying such products and services. Nothing herein should be construed as
- * constituting an additional warranty. Open Text shall not be liable for technical
- * or editorial errors or omissions contained herein.
- * The information contained herein is subject to change without notice.
- * ___________________________________________________________________
- */
+* Certain versions of software and/or documents ("Material") accessible here may contain branding from
+* Hewlett-Packard Company (now HP Inc.) and Hewlett Packard Enterprise Company.
+* The Material is now offered by Open Text Corporation, a separately owned and operated company.  Any reference to the HP
+* and Hewlett Packard Enterprise/HPE marks is historical in nature, and the HP and Hewlett Packard Enterprise/HPE
+* marks are the property of their respective owners.
+* __________________________________________________________________
+* MIT License
+*
+* Copyright © 2023 Open Text Corporation
+*
+* The only warranties for products and services of Open Text Corporation
+* are set forth in the express warranty statements
+* accompanying such products and services. Nothing herein should be construed as
+* constituting an additional warranty. Open Text shall not be liable for technical
+* or editorial errors or omissions contained herein.
+* The information contained herein is subject to change without notice.
+* ___________________________________________________________________
+*/
 
 package com.adm.bamboo.plugin.performancecenter.impl;
 

--- a/src/main/java/com/adm/bamboo/plugin/performancecenter/impl/PcModelBamboo.java
+++ b/src/main/java/com/adm/bamboo/plugin/performancecenter/impl/PcModelBamboo.java
@@ -1,18 +1,18 @@
 /*
  * Certain versions of software and/or documents ("Material") accessible here may contain branding from
  * Hewlett-Packard Company (now HP Inc.) and Hewlett Packard Enterprise Company.  As of September 1, 2017,
- * the Material is now offered by Micro Focus, a separately owned and operated company.  Any reference to the HP
+ * the Material is now offered by Open Text Corporation, a separately owned and operated company.  Any reference to the HP
  * and Hewlett Packard Enterprise/HPE marks is historical in nature, and the HP and Hewlett Packard Enterprise/HPE
  * marks are the property of their respective owners.
  * __________________________________________________________________
  * MIT License
  *
- * (c) Copyright 2012-2019 Micro Focus or one of its affiliates.
+ * Copyright © 2023 Open Text Corporation
  *
- * The only warranties for products and services of Micro Focus and its affiliates
- * and licensors ("Micro Focus") are set forth in the express warranty statements
+ * The only warranties for products and services of Open Text Corporation
+ * are set forth in the express warranty statements
  * accompanying such products and services. Nothing herein should be construed as
- * constituting an additional warranty. Micro Focus shall not be liable for technical
+ * constituting an additional warranty. Open Text shall not be liable for technical
  * or editorial errors or omissions contained herein.
  * The information contained herein is subject to change without notice.
  * ___________________________________________________________________
@@ -21,9 +21,11 @@
 package com.adm.bamboo.plugin.performancecenter.impl;
 
 
+import com.microfocus.adm.performancecenter.plugins.common.pcentities.PostRunAction;
+import com.microfocus.adm.performancecenter.plugins.common.pcentities.TimeslotDuration;
+
 import java.util.Arrays;
 import java.util.List;
-import com.microfocus.adm.performancecenter.plugins.common.pcentities.*;
 
 /**
  * Created by bemh on 8/6/2017.
@@ -31,28 +33,26 @@ import com.microfocus.adm.performancecenter.plugins.common.pcentities.*;
 public class PcModelBamboo {
 
 
-
-    private final String           pcServerName;
-    private final String           almUserName;
+    private final String pcServerName;
+    private final String almUserName;
     private final String almPassword;
-    private final String           almDomain;
-    private final String           almProject;
-    private final String           testId;
-    private final String           testInstanceId;
-    private final String           autoTestInstanceID;
+    private final String almDomain;
+    private final String almProject;
+    private final String testId;
+    private final String testInstanceId;
+    private final String autoTestInstanceID;
     private final TimeslotDuration timeslotDuration;
     private final PostRunAction postRunAction;
-    private final boolean          vudsMode;
-    private final boolean          sla;
-    private final String           description;
-    private final String          addRunToTrendReport;
-    private String trendReportId;
+    private final boolean vudsMode;
+    private final boolean sla;
+    private final String description;
+    private final String addRunToTrendReport;
     private final boolean HTTPSProtocol;
     private final String proxyOutURL;
     private final String proxyOutUser;
     private final String proxyOutPassword;
     private final boolean authenticateWithToken;
-
+    private String trendReportId;
 
 
     public PcModelBamboo(String pcServerName, String almUserName, String almPassword, String almDomain, String almProject,
@@ -88,6 +88,10 @@ public class PcModelBamboo {
 //        return secretContainer;
 //    }
 
+    public static List<PostRunAction> getPostRunActions() {
+        return Arrays.asList(PostRunAction.values());
+    }
+
     public String getPcServerName() {
 
         return this.pcServerName;
@@ -122,7 +126,7 @@ public class PcModelBamboo {
         return this.testInstanceId;
     }
 
-    public String getAutoTestInstanceID(){
+    public String getAutoTestInstanceID() {
         return this.autoTestInstanceID;
     }
 
@@ -146,28 +150,25 @@ public class PcModelBamboo {
         return this.description;
     }
 
-    public boolean httpsProtocol(){
+    public boolean httpsProtocol() {
         return this.HTTPSProtocol;
     }
 
-    public String getProxyOutURL(){
+    public String getProxyOutURL() {
         return this.proxyOutURL;
     }
 
-    public String getProxyOutUser(){
+    public String getProxyOutUser() {
         return this.proxyOutUser;
     }
 
-    public String getProxyOutPassword(){
+    public String getProxyOutPassword() {
         return this.proxyOutPassword;
     }
 
-    public boolean isAuthenticateWithToken() { return this.authenticateWithToken; }
-
-    public static List<PostRunAction> getPostRunActions() {
-        return Arrays.asList(PostRunAction.values());
+    public boolean isAuthenticateWithToken() {
+        return this.authenticateWithToken;
     }
-
 
     @Override
     public String toString() {
@@ -178,13 +179,13 @@ public class PcModelBamboo {
     public String runParamsToString() {
 
         String vudsModeString = (vudsMode) ? ", VUDsMode='true'" : "";
-        String trendString = ("USE_ID").equals(addRunToTrendReport) ? String.format(", TrendReportID = '%s'",trendReportId) : "";
+        String trendString = ("USE_ID").equals(addRunToTrendReport) ? String.format(", TrendReportID = '%s'", trendReportId) : "";
 
         return String.format("[Domain='%s', Project='%s', TestID='%s', " +
                         "TestInstanceID='%s', TimeslotDuration='%s', PostRunAction='%s'%s%s]",
 
                 almDomain, almProject, testId, testInstanceId,
-                timeslotDuration, postRunAction, vudsModeString, trendString,HTTPSProtocol);
+                timeslotDuration, postRunAction, vudsModeString, trendString, HTTPSProtocol);
     }
 
 
@@ -192,7 +193,7 @@ public class PcModelBamboo {
         return trendReportId;
     }
 
-    public void setTrendReportId(String trendReportId){
+    public void setTrendReportId(String trendReportId) {
         this.trendReportId = trendReportId;
     }
 
@@ -200,7 +201,7 @@ public class PcModelBamboo {
         return addRunToTrendReport;
     }
 
-    public String isHTTPSProtocol(){
+    public String isHTTPSProtocol() {
         if (!HTTPSProtocol)
             return "http";
         return "https";

--- a/src/main/java/com/adm/bamboo/plugin/performancecenter/impl/PcModelBamboo.java
+++ b/src/main/java/com/adm/bamboo/plugin/performancecenter/impl/PcModelBamboo.java
@@ -1,22 +1,22 @@
 /*
- * Certain versions of software and/or documents ("Material") accessible here may contain branding from
- * Hewlett-Packard Company (now HP Inc.) and Hewlett Packard Enterprise Company.  As of September 1, 2017,
- * the Material is now offered by Open Text Corporation, a separately owned and operated company.  Any reference to the HP
- * and Hewlett Packard Enterprise/HPE marks is historical in nature, and the HP and Hewlett Packard Enterprise/HPE
- * marks are the property of their respective owners.
- * __________________________________________________________________
- * MIT License
- *
- * Copyright © 2023 Open Text Corporation
- *
- * The only warranties for products and services of Open Text Corporation
- * are set forth in the express warranty statements
- * accompanying such products and services. Nothing herein should be construed as
- * constituting an additional warranty. Open Text shall not be liable for technical
- * or editorial errors or omissions contained herein.
- * The information contained herein is subject to change without notice.
- * ___________________________________________________________________
- */
+* Certain versions of software and/or documents ("Material") accessible here may contain branding from
+* Hewlett-Packard Company (now HP Inc.) and Hewlett Packard Enterprise Company.
+* The Material is now offered by Open Text Corporation, a separately owned and operated company.  Any reference to the HP
+* and Hewlett Packard Enterprise/HPE marks is historical in nature, and the HP and Hewlett Packard Enterprise/HPE
+* marks are the property of their respective owners.
+* __________________________________________________________________
+* MIT License
+*
+* Copyright © 2023 Open Text Corporation
+*
+* The only warranties for products and services of Open Text Corporation
+* are set forth in the express warranty statements
+* accompanying such products and services. Nothing herein should be construed as
+* constituting an additional warranty. Open Text shall not be liable for technical
+* or editorial errors or omissions contained herein.
+* The information contained herein is subject to change without notice.
+* ___________________________________________________________________
+*/
 
 package com.adm.bamboo.plugin.performancecenter.impl;
 

--- a/src/main/resources/templates/performancecenter/configurePC.ftl
+++ b/src/main/resources/templates/performancecenter/configurePC.ftl
@@ -286,7 +286,7 @@ or Leave empty if not using a local proxy. The following proxy configurations ar
         </td>
         <td>
             <a href="#" title="A Virtual User Day (VUD) license provides you with a specified number of Vusers (VUDs) that you can run an unlimited number of times within a 24 hour period.
-Before using this option, make sure that VUDs licenses are applied in your Micro Focus LoadRunner Enterprise environment." >
+Before using this option, make sure that VUDs licenses are applied in your LoadRunner Enterprise environment." >
                 [@ww.checkbox label='Use VUDs' name='vuds' toggle='true'/]
             </a>
         </td>


### PR DESCRIPTION
- in LRE part of the plugin, rebranding "MicroFocus" to "OpenText".
- updating the dependency com.microfocus.adm.performancecenter to latest available version.