### PR TITLE
US-1760035 | [Bamboo] Normalize the test path in HpToolsLauncher.exe …

### DIFF
--- a/HpToolsLauncher/TestInfo.cs
+++ b/HpToolsLauncher/TestInfo.cs
@@ -44,7 +44,7 @@ namespace HpToolsLauncher
     {
         public TestInfo(string testPath)
         {
-            TestPath = testPath;
+            TestPath = Path.GetFullPath(testPath);
         }
         public string GenerateAPITestXmlForTest()
         {


### PR DESCRIPTION
…to prevent max length exceeded